### PR TITLE
Added a constant duration for mircoseconds that is missing

### DIFF
--- a/source/src/Duration.cpp
+++ b/source/src/Duration.cpp
@@ -40,6 +40,7 @@
 namespace r2d2{
 const Duration Duration::SECOND(1.0);
 const Duration Duration::MILLISECOND(1.0/1000.0);
+const Duration Duration::MICROSECOND(1.0/1000.0/1000.0);
 const Duration Duration::MINUTE(60.0);
 
 Duration::Duration():


### PR DESCRIPTION
Need this for the sensorInterface project.
