### PR TITLE
Hotfix microseconds

### DIFF
--- a/source/include/Duration.hpp
+++ b/source/include/Duration.hpp
@@ -131,6 +131,7 @@ class Duration : public ADT_Base<Duration>{
         
         static const Duration SECOND;
         static const Duration MILLISECOND;
+        static const Duration MICROSECOND;
         static const Duration MINUTE;
 };
 }

--- a/source/src/Duration.cpp
+++ b/source/src/Duration.cpp
@@ -40,6 +40,7 @@
 namespace r2d2{
 const Duration Duration::SECOND(1.0);
 const Duration Duration::MILLISECOND(1.0/1000.0);
+const Duration Duration::MICROSECOND(1.0/1000.0/1000.0);
 const Duration Duration::MINUTE(60.0);
 
 Duration::Duration():


### PR DESCRIPTION
Added a constant duration for mircoseconds that is missing
